### PR TITLE
make sure errors in shader compilation on hot reload don't segfault

### DIFF
--- a/src/sdf_renderer.cpp
+++ b/src/sdf_renderer.cpp
@@ -88,7 +88,16 @@ void SDFRenderer::setupRenderContext() {
 
 void SDFRenderer::createPipeline() {
     pipelineLayout = vkutils::createPipelineLayout(logicalDevice);
-    auto fragSpirvPath = shader_utils::compile(fragShaderPath, useToyTemplate);
+    std::filesystem::path fragSpirvPath;
+    try {
+        fragSpirvPath = shader_utils::compile(fragShaderPath, useToyTemplate);
+    } catch (const std::runtime_error &e) {
+        // An error occured while compiling the shader
+        // This can happen while doing live edits
+        // Just try find the old one until the error is fixed
+        fragSpirvPath = fragShaderPath;
+        fragSpirvPath.replace_extension(".spv");
+    }
     fragShaderModule =
         vkutils::createShaderModule(logicalDevice, fragSpirvPath);
     pipeline = vkutils::createGraphicsPipeline(

--- a/src/shader_utils.cpp
+++ b/src/shader_utils.cpp
@@ -130,6 +130,11 @@ std::filesystem::path compile(const std::string &shaderFilename,
     spdlog::info("Shader linked: {}", linked);
     spdlog::info("Program info log: {}", program.getInfoLog());
 
+    if (!linked) {
+        spdlog::error("Failed to link shader program");
+        throw std::runtime_error("Failed to link shader program");
+    }
+
     // Now save SPIR-V binary to a file
     std::vector<unsigned int> spirv;
     spv::SpvBuildLogger logger{};


### PR DESCRIPTION
While live coding shader and viewing output, you will have shader compilation errors that you view in the console and then fix as you go. That should not cause a sefault. Only the initial compilation on first run of the program should require a valid shader to begin with (actually maybe should question this?)