### PR TITLE
Remove CI notes for CPU Vulkan driver from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,6 @@ cmake --build build
 ./build/tests/filewatcher/filewatcher_tests
 ```
 
-### CI Notes (CPU Vulkan driver)
-- On Ubuntu runners install a CPU Vulkan ICD such as `mesa-vulkan-drivers` (lavapipe) and `xvfb`:
-  ```sh
-  sudo apt-get update
-  sudo apt-get install -y mesa-vulkan-drivers xvfb \
-    cmake ninja-build g++ libgtest-dev libspdlog-dev libglfw3 libglfw3-dev \
-    libvulkan-dev glslang-tools glslang-dev libglm-dev
-  ```
-- Run the renderer headless for one frame with a fake display:
-  ```sh
-  VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json \
-    xvfb-run -s "-screen 0 1024x768x24" \
-    ./build/vsdf --toy shaders/testtoyshader.frag --frames 1 --headless --log-level debug
-  ```
-
 ## Nix Develop Shell
 ```sh
 nix develop


### PR DESCRIPTION
Removed CI notes for CPU Vulkan driver installation and usage.