### PR TITLE
Add OS support table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ That way you can use your favourite editor / LSP and also utilise git.
 ## Platforms
 Supports macOS, Linux, and Windows with native file watcher implementations for each platform.
 
+| OS | Support |
+| --- | --- |
+| Windows | ✅ Supported |
+| Linux | ✅ Supported |
+| macOS | ✅ Supported |
+
 ## Mac Dev Setup (Homebrew)
 Install Vulkan + deps with Homebrew (Quickstart + macOS CI):
 ```sh


### PR DESCRIPTION
### Motivation
- Make platform support explicit and easier to scan by adding a concise visual indicator for supported OSes.
- Improve README readability under the existing `Platforms` section.

### Description
- Insert a markdown table under the `Platforms` heading in `README.md` listing `Windows`, `Linux`, and `macOS` with `✅ Supported` statuses.
- This is a documentation-only change and does not modify any source code or build logic.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962004064b0832ea49985dfa73e7bd7)