### PR TITLE
test case to address #36 duration issue

### DIFF
--- a/tests/test_ffmpeg_encode.cpp
+++ b/tests/test_ffmpeg_encode.cpp
@@ -62,6 +62,13 @@ TEST(FFmpegEncoder, EncodesSmallMp4) {
     ASSERT_TRUE(std::filesystem::exists(tempPath));
     ASSERT_GT(std::filesystem::file_size(tempPath), 0u);
 
+    // Prevent duration issues such as https://github.com/jamylak/vsdf/issues/36
+    const auto metadata =
+        ffmpeg_test_utils::probeVideoMetadata(tempPath.string());
+    const double expectedDuration = static_cast<double>(10) / settings.fps;
+    EXPECT_GT(metadata.durationSeconds, 0.0);
+    EXPECT_NEAR(metadata.durationSeconds, expectedDuration, 0.05);
+
     const auto decoded =
         ffmpeg_test_utils::decodeVideoRgb24(tempPath.string());
     EXPECT_EQ(decoded.width, width);


### PR DESCRIPTION
When running without the fix from 4d20aac it gets this:

```
[libx264 @ 0x7c4cf4380] kb/s:8.16
/Users/james/bar/vsdf-duration-bug/tests/test_ffmpeg_encode.cpp:69: Failure
The difference between metadata.durationSeconds and expectedDuration is 0.29941433333333334, which exceeds 0.05, where
metadata.durationSeconds evaluates to 0.033918999999999998, expectedDuration evaluates to 0.33333333333333331, and 0.05 evaluates to 0.050000000000000003.

[swscaler @ 0x7c692c000] No accelerated colorspace conversion found from yuv420p to rgb24.
[  FAILED  ] FFmpegEncoder.EncodesSmallMp4 (13 ms) [----------] 1 test from FFmpegEncoder (13 ms total)
```

Which seems to show it would have caught that issue if it were there

Fixes #36 