### PR TITLE
fix to handle release build issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         brew install glfw glslang spdlog glm vulkan-tools ffmpeg pkg-config
 
     - name: Configure CMake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} .
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DCMAKE_CXX_FLAGS="-Wno-error=sign-conversion -Wno-error=implicit-int-conversion" .
 
     - name: Build
       run: cmake --build build


### PR DESCRIPTION
```
Run cmake --build build
[ 10%] Building CXX object CMakeFiles/vsdf.dir/src/main.cpp.o In file included from /Users/runner/work/vsdf/vsdf/src/main.cpp:4: In file included from
/Users/runner/work/vsdf/vsdf/include/offline_sdf_renderer.h:5: In file included from
/Users/runner/work/vsdf/vsdf/include/ffmpeg_encoder.h:7: In file included from /usr/local/include/libavcodec/avcodec.h:32: In file included from /usr/local/include/libavutil/avutil.h:300: /usr/local/include/libavutil/common.h:212:31: error: implicit conversion changes signedness: 'int' to 'uint8_t' (aka 'unsigned char') [-Werror,-Wsign-conversion]
  212 |     if (a&(~0xFF)) return (~a)>>31;
      |                    ~~~~~~ ~~~~^~~~
/usr/local/include/libavutil/common.h:213:27: error: implicit conversion
loses integer precision: 'int' to 'uint8_t' (aka 'unsigned char')
[-Werror,-Wimplicit-int-conversion]
  213 |     else           return a;
      |                    ~~~~~~ ^
/usr/local/include/libavutil/common.h:223:21: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  223 |     if ((a+0x80U) & ~0xFF) return (a>>31) ^ 0x7F;
      |                   ~ ^~~~~
/usr/local/include/libavutil/common.h:223:10: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  223 |     if ((a+0x80U) & ~0xFF) return (a>>31) ^ 0x7F;
      |          ^~
/usr/local/include/libavutil/common.h:224:34: error: implicit conversion
loses integer precision: 'int' to 'int8_t' (aka 'signed char')
[-Werror,-Wimplicit-int-conversion]
  224 |     else                  return a;
      |                           ~~~~~~ ^
/usr/local/include/libavutil/common.h:234:33: error: implicit conversion
changes signedness: 'int' to 'uint16_t' (aka 'unsigned short')
[-Werror,-Wsign-conversion]
  234 |     if (a&(~0xFFFF)) return (~a)>>31;
      |                      ~~~~~~ ~~~~^~~~
/usr/local/include/libavutil/common.h:235:29: error: implicit conversion
loses integer precision: 'int' to 'uint16_t' (aka 'unsigned short')
[-Werror,-Wimplicit-int-conversion]
  235 |     else             return a;
      |                      ~~~~~~ ^
/usr/local/include/libavutil/common.h:245:23: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  245 |     if ((a+0x8000U) & ~0xFFFF) return (a>>31) ^ 0x7FFF;
      |                     ~ ^~~~~~~
/usr/local/include/libavutil/common.h:245:10: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  245 |     if ((a+0x8000U) & ~0xFFFF) return (a>>31) ^ 0x7FFF;
      |          ^~
/usr/local/include/libavutil/common.h:246:38: error: implicit conversion
loses integer precision: 'int' to 'int16_t' (aka 'short')
[-Werror,-Wimplicit-int-conversion]
  246 |     else                      return a;
      |                               ~~~~~~ ^
/usr/local/include/libavutil/common.h:256:10: error: implicit conversion
changes signedness: 'int64_t' (aka 'long long') to 'unsigned long long'
[-Werror,-Wsign-conversion]
  256 |     if ((a+UINT64_C(0x80000000)) & ~UINT64_C(0xFFFFFFFF)) return
(int32_t)((a>>63) ^ 0x7FFFFFFF);
      |          ^~
/usr/local/include/libavutil/common.h:282:9: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  282 |     if (a & ~((1U<<p) - 1)) return (~a) >> 31 & ((1U<<p) - 1);
      |         ^ ~
/usr/local/include/libavutil/common.h:282:41: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  282 |     if (a & ~((1U<<p) - 1)) return (~a) >> 31 & ((1U<<p) - 1);
      |                                    ~~~~~^~~~~ ~
/usr/local/include/libavutil/common.h:283:37: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  283 |     else                    return  a;
      |                             ~~~~~~  ^
/usr/local/include/libavutil/common.h:438:21: error: implicit conversion
changes signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
  438 |     return av_log2((x - 1U) << 1);
      |                     ^ ~
15 errors generated.
make[2]: *** [CMakeFiles/vsdf.dir/src/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/vsdf.dir/all] Error 2
make: *** [all] Error 2
Error: Process completed with exit code 2.
```

https://github.com/jamylak/vsdf/actions/runs/20944688451/job/60185297600#step:5:1

As part of the release binaries build