### PR TITLE
Build fixes for releases

### DIFF
--- a/.github/workflows/linux-docker-ci.yml
+++ b/.github/workflows/linux-docker-ci.yml
@@ -26,7 +26,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
       
     - name: Build Docker image
       run: docker build -t linux-tests -f linux-tests.Dockerfile .

--- a/.github/workflows/linux-smoke-tests.yml
+++ b/.github/workflows/linux-smoke-tests.yml
@@ -24,6 +24,8 @@ jobs:
       VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -27,7 +27,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/nix-flake-ci.yml
+++ b/.github/workflows/nix-flake-ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install Nix
         uses: cachix/install-nix-action@v24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Install dependencies
       run: |
@@ -116,7 +118,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Install dependencies
       run: |
@@ -224,7 +228,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Install dependencies via vcpkg
       timeout-minutes: 25
@@ -271,7 +277,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Download all artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,81 @@ jobs:
     - name: Build
       run: cmake --build build
 
+    - name: Bundle dependencies and fix paths
+      run: |
+        # Create libs directory
+        mkdir -p release/macos/libs
+        
+        # Copy the binary
+        cp build/vsdf release/macos/
+        
+        # Find and copy all non-system dylibs
+        echo "Bundling dynamic libraries..."
+        
+        # Get list of dynamic libraries (excluding system ones)
+        DYLIBS=$(otool -L build/vsdf | grep -E "(glslang|spirv-tools|ffmpeg|libav)" | awk '{print $1}')
+        
+        for lib in $DYLIBS; do
+          if [ -f "$lib" ]; then
+            libname=$(basename "$lib")
+            echo "Copying $libname"
+            cp "$lib" release/macos/libs/
+            
+            # Also copy any dependencies of this library
+            SUB_DYLIBS=$(otool -L "$lib" | grep -E "(glslang|spirv-tools|ffmpeg|libav)" | awk '{print $1}')
+            for sublib in $SUB_DYLIBS; do
+              if [ -f "$sublib" ]; then
+                sublibname=$(basename "$sublib")
+                if [ ! -f "release/macos/libs/$sublibname" ]; then
+                  echo "Copying dependency $sublibname"
+                  cp "$sublib" release/macos/libs/
+                fi
+              fi
+            done
+          fi
+        done
+        
+        # Fix all library paths to use @rpath
+        echo "Fixing library paths..."
+        
+        # Fix paths in the main binary
+        for lib in release/macos/libs/*.dylib; do
+          libname=$(basename "$lib")
+          # Find the original path in the binary
+          ORIG_PATH=$(otool -L release/macos/vsdf | grep "$libname" | awk '{print $1}')
+          if [ ! -z "$ORIG_PATH" ]; then
+            echo "Fixing $libname in vsdf"
+            install_name_tool -change "$ORIG_PATH" "@rpath/libs/$libname" release/macos/vsdf
+          fi
+        done
+        
+        # Fix inter-library dependencies
+        for lib in release/macos/libs/*.dylib; do
+          libname=$(basename "$lib")
+          echo "Fixing paths in $libname"
+          
+          # Fix the library's own id
+          install_name_tool -id "@rpath/libs/$libname" "$lib"
+          
+          # Fix references to other bundled libraries
+          for otherlib in release/macos/libs/*.dylib; do
+            othername=$(basename "$otherlib")
+            ORIG_PATH=$(otool -L "$lib" | grep "$othername" | awk '{print $1}')
+            if [ ! -z "$ORIG_PATH" ] && [ "$ORIG_PATH" != "@rpath/libs/$othername" ]; then
+              install_name_tool -change "$ORIG_PATH" "@rpath/libs/$othername" "$lib"
+            fi
+          done
+        done
+        
+        echo "Bundle complete!"
+        echo "Bundled libraries:"
+        ls -lh release/macos/libs/
+        
+        echo "Binary dependencies after fixing:"
+        otool -L release/macos/vsdf
+
     - name: Package binary
       run: |
-        mkdir -p release/macos
-        cp build/vsdf release/macos/
         cp -r shaders release/macos/
         cp README.md release/macos/
         cp LICENSE release/macos/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   build-linux:
     name: Build Linux Release
-    runs-on: ubuntu-latest
+    # Use Ubuntu 20.04 for maximum glibc/libstdc++ compatibility
+    # Binaries built here work on Ubuntu 20.04+ and most modern distros (Debian 11+, Fedora 32+, Arch, etc.)
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,59 @@ jobs:
     - name: Build
       run: cmake --build build
 
-    - name: Package binary
+    - name: Install patchelf for fixing library paths
+      run: sudo apt-get install -y patchelf
+
+    - name: Bundle dependencies and fix paths
       run: |
-        mkdir -p release/linux
+        mkdir -p release/linux/libs
         cp build/vsdf release/linux/
         chmod +x release/linux/vsdf
+        
+        echo "Bundling dynamic libraries..."
+        
+        # Find non-system libraries
+        ldd build/vsdf | grep -E "(glslang|SPIRV|ffmpeg|libav)" | awk '{print $3}' | while read lib; do
+          if [ -f "$lib" ]; then
+            libname=$(basename "$lib")
+            echo "Copying $libname"
+            cp "$lib" release/linux/libs/
+            
+            # Also copy dependencies of this library
+            ldd "$lib" 2>/dev/null | grep -E "(glslang|SPIRV|ffmpeg|libav)" | awk '{print $3}' | while read sublib; do
+              if [ -f "$sublib" ]; then
+                sublibname=$(basename "$sublib")
+                if [ ! -f "release/linux/libs/$sublibname" ]; then
+                  echo "  -> Copying dependency $sublibname"
+                  cp "$sublib" release/linux/libs/
+                fi
+              fi
+            done
+          fi
+        done
+        
+        echo "Fixing library paths..."
+        
+        # Set RPATH on main binary to look in libs/ folder
+        patchelf --set-rpath '$ORIGIN/libs' release/linux/vsdf
+        
+        # Fix RPATH for each bundled library
+        for lib in release/linux/libs/*.so*; do
+          [ -f "$lib" ] && patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null || true
+        done
+        
+        echo "Bundle complete!"
+        echo "Bundled libraries:"
+        ls -lh release/linux/libs/
+        
+        echo "Binary RPATH:"
+        patchelf --print-rpath release/linux/vsdf
+        
+        echo "Binary dependencies:"
+        ldd release/linux/vsdf | head -20
+
+    - name: Package binary
+      run: |
         cp -r shaders release/linux/
         cp README.md release/linux/
         cp LICENSE release/linux/

--- a/.github/workflows/windows-build-test.yml
+++ b/.github/workflows/windows-build-test.yml
@@ -29,7 +29,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Install dependencies via vcpkg
       timeout-minutes: 15

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/volk"]
+	path = external/volk
+	url = https://github.com/zeux/volk.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,8 @@ project(vsdf)
 # Prefer static libraries for Release builds (except FFmpeg which has too many deps)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "Release build - preferring static libraries where practical")
-    # Note: We keep FFmpeg dynamic due to its extensive dependency chain
+    # Note: We keep FFmpeg and system libraries (libstdc++) dynamic
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".dylib" ".so")
-    
-    # Link statically to C++ stdlib on Linux
-    if(UNIX AND NOT APPLE)
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
-    endif()
 else()
     message(STATUS "Debug build - using dynamic libraries")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,8 @@ if(APPLE)
   # @executable_path/libs - for bundled dylibs in release packages
   # /usr/local/lib, /opt/homebrew/lib - for development builds with Homebrew
   set_target_properties(${PROJECT_NAME} PROPERTIES
-      BUILD_RPATH "@executable_path/libs;@executable_path;/usr/local/lib;/opt/homebrew/lib"
-      INSTALL_RPATH "@executable_path/libs;@executable_path;/usr/local/lib;/opt/homebrew/lib"
+      BUILD_RPATH "@executable_path/libs;/usr/local/lib;/opt/homebrew/lib"
+      INSTALL_RPATH "@executable_path/libs;/usr/local/lib;/opt/homebrew/lib"
   )
   
   # When static linking GLFW on macOS, we need these frameworks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,13 @@ else()
 endif()
 
 # Vulkan: Only need headers for volk, not the loader library or tools
-find_package(Vulkan REQUIRED)
+if(WIN32)
+    # On Windows, only require headers (volk handles loader)
+    find_package(Vulkan REQUIRED COMPONENTS Headers)
+else()
+    # On Unix, standard package detection works fine
+    find_package(Vulkan REQUIRED)
+endif()
 find_package(glslang REQUIRED)
 find_package(glm REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,12 @@ if(APPLE)
   find_library(CORE_SERVICES_LIBRARY CoreServices)
   target_link_libraries(${PROJECT_NAME} PRIVATE ${CORE_SERVICES_LIBRARY})
   
-  # Volk will find Vulkan dynamically - no hardcoded paths needed
-  # But keep RPATH for potential dynamic FFmpeg if not statically linked
+  # RPATH settings for finding bundled libraries
+  # @executable_path/libs - for bundled dylibs in release packages
+  # /usr/local/lib, /opt/homebrew/lib - for development builds with Homebrew
   set_target_properties(${PROJECT_NAME} PROPERTIES
-      BUILD_RPATH "@executable_path;/usr/local/lib;/opt/homebrew/lib"
-      INSTALL_RPATH "@executable_path;/usr/local/lib;/opt/homebrew/lib"
+      BUILD_RPATH "@executable_path/libs;@executable_path;/usr/local/lib;/opt/homebrew/lib"
+      INSTALL_RPATH "@executable_path/libs;@executable_path;/usr/local/lib;/opt/homebrew/lib"
   )
   
   # When static linking GLFW on macOS, we need these frameworks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,7 @@ else()
 endif()
 
 # Vulkan: Only need headers for volk, not the loader library or tools
-if(WIN32)
-    # On Windows, only require headers (volk handles loader)
-    find_package(Vulkan REQUIRED COMPONENTS Headers)
-else()
-    # On Unix, standard package detection works fine
-    find_package(Vulkan REQUIRED)
-endif()
+find_package(Vulkan REQUIRED)
 find_package(glslang REQUIRED)
 find_package(glm REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,50 @@ cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 20)
 project(vsdf)
 
-find_package(glfw3 REQUIRED)
-find_package(Vulkan REQUIRED)
+# Prefer static libraries for Release builds (except FFmpeg which has too many deps)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(STATUS "Release build - preferring static libraries where practical")
+    # Note: We keep FFmpeg dynamic due to its extensive dependency chain
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".dylib" ".so")
+    
+    # Link statically to C++ stdlib on Linux
+    if(UNIX AND NOT APPLE)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+    endif()
+else()
+    message(STATUS "Debug build - using dynamic libraries")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
+endif()
+
+# For Release builds, try to find static versions of key libraries
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    # Try to find static glfw
+    find_library(GLFW_STATIC_LIB NAMES libglfw3.a glfw3 PATHS /opt/homebrew/opt/glfw/lib /usr/local/lib NO_DEFAULT_PATH)
+    if(GLFW_STATIC_LIB)
+        message(STATUS "Found static glfw: ${GLFW_STATIC_LIB}")
+        set(glfw3_FOUND TRUE)
+    else()
+        find_package(glfw3 REQUIRED)
+    endif()
+    
+    # Try to find static spdlog (needs fmt too)
+    find_library(SPDLOG_STATIC_LIB NAMES libspdlog.a spdlog PATHS /opt/homebrew/opt/spdlog/lib /usr/local/lib NO_DEFAULT_PATH)
+    find_library(FMT_STATIC_LIB NAMES libfmt.a fmt PATHS /opt/homebrew/opt/fmt/lib /usr/local/lib NO_DEFAULT_PATH)
+    if(SPDLOG_STATIC_LIB AND FMT_STATIC_LIB)
+        message(STATUS "Found static spdlog: ${SPDLOG_STATIC_LIB}")
+        message(STATUS "Found static fmt: ${FMT_STATIC_LIB}")
+        set(spdlog_FOUND TRUE)
+    else()
+        find_package(spdlog REQUIRED)
+    endif()
+else()
+    find_package(glfw3 REQUIRED)
+    find_package(spdlog REQUIRED)
+endif()
+
+# Vulkan: Only need headers for volk, not the loader library
+find_package(Vulkan REQUIRED COMPONENTS glslc glslangValidator)
 find_package(glslang REQUIRED)
-find_package(spdlog REQUIRED)
 find_package(glm REQUIRED)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -35,6 +75,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT MSVC)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
 endif()
+
+# Add volk for Vulkan meta-loader
+add_subdirectory(external/volk)
 
 add_executable(${PROJECT_NAME} src/main.cpp src/shader_utils.cpp src/sdf_renderer.cpp src/online_sdf_renderer.cpp src/image_dump.cpp)
 
@@ -61,11 +104,21 @@ if(APPLE)
   target_sources(${PROJECT_NAME} PRIVATE src/filewatcher/mac_filewatcher.cpp)
   find_library(CORE_SERVICES_LIBRARY CoreServices)
   target_link_libraries(${PROJECT_NAME} PRIVATE ${CORE_SERVICES_LIBRARY})
-  # Lunar https://vulkan.lunarg.com/doc/sdk/1.4.328.1/mac/getting_started.html
+  
+  # Volk will find Vulkan dynamically - no hardcoded paths needed
+  # But keep RPATH for potential dynamic FFmpeg if not statically linked
   set_target_properties(${PROJECT_NAME} PROPERTIES
-      BUILD_RPATH "/usr/local/lib"
-      INSTALL_RPATH "/usr/local/lib"
+      BUILD_RPATH "@executable_path;/usr/local/lib;/opt/homebrew/lib"
+      INSTALL_RPATH "@executable_path;/usr/local/lib;/opt/homebrew/lib"
   )
+  
+  # When static linking GLFW on macOS, we need these frameworks
+  if(CMAKE_BUILD_TYPE STREQUAL "Release" AND GLFW_STATIC_LIB)
+    find_library(COCOA_LIBRARY Cocoa REQUIRED)
+    find_library(IOKIT_LIBRARY IOKit REQUIRED)
+    find_library(COREVIDEO_LIBRARY CoreVideo REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${COCOA_LIBRARY} ${IOKIT_LIBRARY} ${COREVIDEO_LIBRARY})
+  endif()
 elseif(UNIX AND NOT APPLE)
   # Print building linux
   message("Building filewatcher for Linux")
@@ -77,7 +130,26 @@ elseif(WIN32)
   target_sources(${PROJECT_NAME} PRIVATE src/filewatcher/windows_filewatcher.cpp)
 endif()
 
-target_link_libraries(${PROJECT_NAME} PRIVATE glfw Vulkan::Vulkan spdlog::spdlog glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV)
+# Link libraries - use static versions when found for Release builds
+if(CMAKE_BUILD_TYPE STREQUAL "Release" AND GLFW_STATIC_LIB)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${GLFW_STATIC_LIB})
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
+endif()
+
+target_link_libraries(${PROJECT_NAME} PRIVATE volk)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release" AND SPDLOG_STATIC_LIB AND FMT_STATIC_LIB)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${SPDLOG_STATIC_LIB} ${FMT_STATIC_LIB})
+    target_include_directories(${PROJECT_NAME} PRIVATE /opt/homebrew/opt/spdlog/include)
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE spdlog::spdlog)
+endif()
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV)
+
+# Include Vulkan headers for types (volk needs them)
+target_include_directories(${PROJECT_NAME} PRIVATE ${Vulkan_INCLUDE_DIRS})
 include_directories(${PROJECT_NAME} PRIVATE include ${GLM_INCLUDE_DIRS})
 
 if (VSDF_ENABLE_FFMPEG)
@@ -90,10 +162,17 @@ if (VSDF_ENABLE_FFMPEG)
       FFMPEG::avutil
       FFMPEG::swscale)
   else()
+    # Temporarily restore dynamic library preference for FFmpeg (too many static deps)
+    set(_SAVED_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
+    
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
       libavformat libavcodec libavutil libswscale)
     target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::FFMPEG)
+    
+    # Restore library suffix preference
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_SAVED_SUFFIXES})
   endif()
   target_compile_definitions(${PROJECT_NAME} PRIVATE VSDF_ENABLE_FFMPEG=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,12 @@ elseif(UNIX AND NOT APPLE)
   find_package(Threads REQUIRED)
   target_sources(${PROJECT_NAME} PRIVATE src/filewatcher/linux_filewatcher.cpp)
   target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
+  
+  # RPATH settings for finding bundled libraries on Linux
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+      BUILD_RPATH "$ORIGIN/libs:$ORIGIN"
+      INSTALL_RPATH "$ORIGIN/libs:$ORIGIN"
+  )
 elseif(WIN32)
   message("Building filewatcher for Windows")
   target_sources(${PROJECT_NAME} PRIVATE src/filewatcher/windows_filewatcher.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,17 @@ project(vsdf)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "Release build - preferring static libraries where practical")
     # Note: We keep FFmpeg and system libraries (libstdc++) dynamic
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".dylib" ".so")
+    if(WIN32)
+        # Windows static and import libs use .lib; keep defaults for other suffixes.
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".a")
+    else()
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".dylib" ".so")
+    endif()
 else()
     message(STATUS "Debug build - using dynamic libraries")
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
+    if(NOT WIN32)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib" ".so" ".a")
+    endif()
 endif()
 
 # For Release builds, try to find static versions of key libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ else()
     find_package(spdlog REQUIRED)
 endif()
 
-# Vulkan: Only need headers for volk, not the loader library
-find_package(Vulkan REQUIRED COMPONENTS glslc glslangValidator)
+# Vulkan: Only need headers for volk, not the loader library or tools
+find_package(Vulkan REQUIRED)
 find_package(glslang REQUIRED)
 find_package(glm REQUIRED)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,21 @@
-MIT License
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
 
-Copyright (c) 2024 James Karefylakis
+Copyright (C) 2024 James Karefylakis
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+For the full GPL-3.0 license text, see: https://www.gnu.org/licenses/gpl-3.0.txt

--- a/README.md
+++ b/README.md
@@ -13,13 +13,26 @@ Vulkan SDF Renderer + Hot Reloader
 
 ## Runtime Requirements for Binary Releases
 
-To run the pre-built binaries, you only need:
-- **Vulkan 1.2+** runtime installed
+The pre-built binaries are **self-contained** and include all necessary libraries (glslang, FFmpeg) in the `libs/` folder.
+
+You only need to install:
+- **Vulkan 1.2+** runtime
   - macOS: Install [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) or `brew install molten-vk`
   - Linux: Install `libvulkan1` and GPU drivers (Mesa/NVIDIA/AMD)
-- **FFmpeg** (optional, for video export): `brew install ffmpeg` / `apt install ffmpeg`
 
 The binary uses [volk](https://github.com/zeux/volk) to dynamically find Vulkan at runtime, so it works regardless of installation location.
+
+**Package contents:**
+```
+vsdf-macos/
+├── vsdf          # Main binary (~1MB)
+├── libs/         # Bundled libraries (~64MB)
+│   ├── libglslang*.dylib
+│   ├── libSPIRV*.dylib  
+│   └── libav*.dylib (FFmpeg)
+├── shaders/      # Example shaders
+└── README.md
+```
 
 Quickstart: see [QUICKSTART.md](QUICKSTART.md) for install + first shader.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ Vulkan SDF Renderer + Hot Reloader
 
 ![Preview](https://i.imgur.com/88KG4NL.gif)
 
+## License
+**VSDF is licensed under GPL-3.0** (changed from MIT to enable static linking with GPL-licensed FFmpeg).
+
+## Runtime Requirements for Binary Releases
+
+To run the pre-built binaries, you only need:
+- **Vulkan 1.2+** runtime installed
+  - macOS: Install [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) or `brew install molten-vk`
+  - Linux: Install `libvulkan1` and GPU drivers (Mesa/NVIDIA/AMD)
+- **FFmpeg** (optional, for video export): `brew install ffmpeg` / `apt install ffmpeg`
+
+The binary uses [volk](https://github.com/zeux/volk) to dynamically find Vulkan at runtime, so it works regardless of installation location.
+
 Quickstart: see [QUICKSTART.md](QUICKSTART.md) for install + first shader.
 
 Render an SDF like ShaderToy using Vulkan and hot reload based on frag shader changes.

--- a/README.md
+++ b/README.md
@@ -9,30 +9,7 @@ Vulkan SDF Renderer + Hot Reloader
 ![Preview](https://i.imgur.com/88KG4NL.gif)
 
 ## License
-**VSDF is licensed under GPL-3.0** (changed from MIT to enable static linking with GPL-licensed FFmpeg).
-
-## Runtime Requirements for Binary Releases
-
-The pre-built binaries are **self-contained** and include all necessary libraries (glslang, FFmpeg) in the `libs/` folder.
-
-You only need to install:
-- **Vulkan 1.2+** runtime
-  - macOS: Install [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) or `brew install molten-vk`
-  - Linux: Install `libvulkan1` and GPU drivers (Mesa/NVIDIA/AMD)
-
-The binary uses [volk](https://github.com/zeux/volk) to dynamically find Vulkan at runtime, so it works regardless of installation location.
-
-**Package contents:**
-```
-vsdf-macos/
-├── vsdf          # Main binary (~1MB)
-├── libs/         # Bundled libraries (~64MB)
-│   ├── libglslang*.dylib
-│   ├── libSPIRV*.dylib  
-│   └── libav*.dylib (FFmpeg)
-├── shaders/      # Example shaders
-└── README.md
-```
+**VSDF is licensed under GPL-3.0**
 
 Quickstart: see [QUICKSTART.md](QUICKSTART.md) for install + first shader.
 
@@ -217,6 +194,9 @@ cmake --build build --config Debug
 ```sh
 nix develop
 ```
+
+The binary uses [volk](https://github.com/zeux/volk) to dynamically find Vulkan at runtime, so it works regardless of installation location.
+
 
 ### Credits:
 - https://shadertoy.com

--- a/default.nix
+++ b/default.nix
@@ -12,13 +12,28 @@
 , llvmPackages_21
 , ffmpeg
 , pkg-config
+, fetchFromGitHub
 }:
 
+let
+  volk = fetchFromGitHub {
+    owner = "zeux";
+    repo = "volk";
+    rev = "d34b5e0d46b28c22d69b97ee7da074b6e68d9e25";
+    sha256 = "0fm6i4bb1c4dj148x8zvrqzc18cdvnq71zl86l38nnvmy5ncvz69";
+  };
+in
 stdenv.mkDerivation {
   pname = "vsdf";
   version = "0.1.0";
 
   src = ./.;
+
+  postUnpack = ''
+    rmdir $sourceRoot/external/volk || true
+    cp -r ${volk} $sourceRoot/external/volk
+    chmod -R +w $sourceRoot/external/volk
+  '';
 
   nativeBuildInputs = [
     cmake

--- a/include/glfwutils.h
+++ b/include/glfwutils.h
@@ -1,8 +1,9 @@
 #ifndef GLFWUTILS_H
 #define GLFWUTILS_H
 
-#define GLFW_INCLUDE_VULKAN
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+#include <volk.h>
 #include <stdexcept>
 #include <string>
 
@@ -14,8 +15,8 @@
 namespace glfwutils {
 
 /**
- * Initializes GLFW library. Throws runtime_error if initialization fails.
- * Ensures GLFW is only initialized once.
+ * Initializes GLFW library and volk. Throws runtime_error if initialization fails.
+ * Ensures GLFW and volk are only initialized once.
  */
 static void initGLFW() {
     static bool isInitialized = false;
@@ -24,6 +25,14 @@ static void initGLFW() {
             throw std::runtime_error("Failed to initialize GLFW");
         }
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API); // No OpenGL context
+        
+        // Initialize volk after GLFW
+        VkResult result = volkInitialize();
+        if (result != VK_SUCCESS) {
+            glfwTerminate();
+            throw std::runtime_error("Failed to initialize volk (Vulkan loader not found)");
+        }
+        
         isInitialized = true;
     }
 }

--- a/include/glfwutils.h
+++ b/include/glfwutils.h
@@ -3,7 +3,6 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
-#include <volk.h>
 #include <stdexcept>
 #include <string>
 
@@ -15,8 +14,8 @@
 namespace glfwutils {
 
 /**
- * Initializes GLFW library and volk. Throws runtime_error if initialization fails.
- * Ensures GLFW and volk are only initialized once.
+ * Initializes GLFW library. Throws runtime_error if initialization fails.
+ * Ensures GLFW is only initialized once.
  */
 static void initGLFW() {
     static bool isInitialized = false;
@@ -25,14 +24,6 @@ static void initGLFW() {
             throw std::runtime_error("Failed to initialize GLFW");
         }
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API); // No OpenGL context
-        
-        // Initialize volk after GLFW
-        VkResult result = volkInitialize();
-        if (result != VK_SUCCESS) {
-            glfwTerminate();
-            throw std::runtime_error("Failed to initialize volk (Vulkan loader not found)");
-        }
-        
         isInitialized = true;
     }
 }

--- a/include/glfwutils.h
+++ b/include/glfwutils.h
@@ -15,17 +15,13 @@ namespace glfwutils {
 
 /**
  * Initializes GLFW library. Throws runtime_error if initialization fails.
- * Ensures GLFW is only initialized once.
+ * Must be called once before creating windows.
  */
 static void initGLFW() {
-    static bool isInitialized = false;
-    if (!isInitialized) {
-        if (!glfwInit()) {
-            throw std::runtime_error("Failed to initialize GLFW");
-        }
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API); // No OpenGL context
-        isInitialized = true;
+    if (!glfwInit()) {
+        throw std::runtime_error("Failed to initialize GLFW");
     }
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API); // No OpenGL context
 }
 
 /**

--- a/include/offline_sdf_renderer.h
+++ b/include/offline_sdf_renderer.h
@@ -12,7 +12,6 @@
 #include <optional>
 #include <string>
 #include <thread>
-#include <vulkan/vulkan.h>
 
 inline constexpr uint32_t OFFSCREEN_DEFAULT_WIDTH = 1280;
 inline constexpr uint32_t OFFSCREEN_DEFAULT_HEIGHT = 720;

--- a/include/online_sdf_renderer.h
+++ b/include/online_sdf_renderer.h
@@ -4,7 +4,6 @@
 #include "vkutils.h"
 #include <filesystem>
 #include <optional>
-#include <vulkan/vulkan.h>
 
 inline constexpr uint32_t WINDOW_WIDTH = 800;
 inline constexpr uint32_t WINDOW_HEIGHT = 600;

--- a/include/sdf_renderer.h
+++ b/include/sdf_renderer.h
@@ -5,7 +5,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <vulkan/vulkan.h>
 
 class SDFRenderer {
   protected:

--- a/include/vkutils.h
+++ b/include/vkutils.h
@@ -15,8 +15,8 @@
 #include <string>
 #include <sys/types.h>
 #include <vector>
-#include <vulkan/vulkan.h>
-#define GLFW_INCLUDE_VULKAN
+#include <volk.h>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 #include <array>
 #include <glm/glm.hpp>
@@ -214,6 +214,10 @@ loadSpvFile(const std::string &filename) {
 
     VkInstance instance;
     VK_CHECK(vkCreateInstance(&createInfo, nullptr, &instance));
+    
+    // Load instance-specific Vulkan functions
+    volkLoadInstance(instance);
+    
     return instance;
 }
 
@@ -391,6 +395,10 @@ createVulkanLogicalDevice(VkPhysicalDevice physicalDevice,
 
     VK_CHECK(
         vkCreateDevice(physicalDevice, &deviceCreateInfo, nullptr, &device));
+    
+    // Load device-specific Vulkan functions
+    volkLoadDevice(device);
+    
     spdlog::debug("Created logical device (offline = {})", offline);
 
     return device;

--- a/include/vkutils.h
+++ b/include/vkutils.h
@@ -126,7 +126,33 @@ loadSpvFile(const std::string &filename) {
     }
 }
 
+/**
+ * Initializes volk meta-loader to find Vulkan dynamically.
+ * Must be called before creating VkInstance.
+ */
+[[nodiscard]] static bool initVolk() {
+    static bool isInitialized = false;
+    if (!isInitialized) {
+        VkResult result = volkInitialize();
+        if (result != VK_SUCCESS) {
+            spdlog::error("Failed to initialize volk: Vulkan loader not found");
+            spdlog::error("Please install Vulkan runtime:");
+            spdlog::error("  macOS: brew install molten-vk");
+            spdlog::error("  Linux: apt install libvulkan1");
+            return false;
+        }
+        spdlog::debug("volk initialized successfully");
+        isInitialized = true;
+    }
+    return true;
+}
+
 [[nodiscard]] static VkInstance setupVulkanInstance(bool offline = false) {
+    // Initialize volk first
+    if (!initVolk()) {
+        throw std::runtime_error("Failed to initialize Vulkan loader (volk)");
+    }
+    
     const VkApplicationInfo appInfo = {
         .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
         .pNext = nullptr,

--- a/include/vkutils.h
+++ b/include/vkutils.h
@@ -128,23 +128,19 @@ loadSpvFile(const std::string &filename) {
 
 /**
  * Initializes volk meta-loader to find Vulkan dynamically.
- * Must be called before creating VkInstance.
+ * Must be called once before creating VkInstance.
  * Throws runtime_error if Vulkan loader not found.
  */
 static void initVolk() {
-    static bool isInitialized = false;
-    if (!isInitialized) {
-        VkResult result = volkInitialize();
-        if (result != VK_SUCCESS) {
-            spdlog::error("Failed to initialize volk: Vulkan loader not found");
-            spdlog::error("Please install Vulkan runtime:");
-            spdlog::error("  macOS: brew install molten-vk");
-            spdlog::error("  Linux: apt install libvulkan1");
-            throw std::runtime_error("Failed to initialize Vulkan loader (volk)");
-        }
-        spdlog::debug("volk initialized successfully");
-        isInitialized = true;
+    VkResult result = volkInitialize();
+    if (result != VK_SUCCESS) {
+        spdlog::error("Failed to initialize volk: Vulkan loader not found");
+        spdlog::error("Please install Vulkan runtime:");
+        spdlog::error("  macOS: brew install molten-vk");
+        spdlog::error("  Linux: apt install libvulkan1");
+        throw std::runtime_error("Failed to initialize Vulkan loader (volk)");
     }
+    spdlog::debug("volk initialized successfully");
 }
 
 [[nodiscard]] static VkInstance setupVulkanInstance(bool offline = false) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(TEST_SOURCES
 )
 
 # Common libraries for all platforms
-set(COMMON_LIBS GTest::gtest_main spdlog::spdlog glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glfw Vulkan::Vulkan)
+set(COMMON_LIBS GTest::gtest_main spdlog::spdlog glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glfw volk)
 
 if (VSDF_ENABLE_FFMPEG)
   list(APPEND TEST_SOURCES
@@ -20,7 +20,7 @@ endif()
 
 # Add test executable
 add_executable(${PROJECT_NAME} ${TEST_SOURCES})
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include ${Vulkan_INCLUDE_DIRS})
 
 # Platform-specific threading library
 if(UNIX)


### PR DESCRIPTION
- Static build some libraries for releases
- For the rest, have relative paths dynamically linked to from the binary eg. `libavformat` and `libglslang` etc
- To be used in Release builds 
  - Mac
  - Linux
  - Windows (Skipping for now - until #33 is addressed)
- Use https://github.com/zeux/volk volk loader to load Vulkan, we only need to statically link Volk
- GPL License