### PR TITLE
Fix Windows Binary Configuration Issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,7 +412,7 @@ jobs:
 
     - name: Build
       timeout-minutes: 10
-      run: cmake --build build --config RelWithDebInfo
+      run: cmake --build build --config Release
 
     - name: Bundle runtime DLLs
       run: |


### PR DESCRIPTION
This solves https://github.com/jamylak/vsdf/issues/58 by converting to `\MT`

Fixes #58 