### PR TITLE
Library cleanup & fixes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(TEST_SOURCES
 )
 
 # Common libraries for all platforms
-set(COMMON_LIBS GTest::gtest_main spdlog::spdlog_header_only glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glfw volk)
+set(COMMON_LIBS GTest::gtest_main spdlog::spdlog glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV glfw volk)
 
 if (VSDF_ENABLE_FFMPEG)
   list(APPEND TEST_SOURCES

--- a/tests/filewatcher/CMakeLists.txt
+++ b/tests/filewatcher/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(${PROJECT_NAME} GTest::gtest_main ${EXTRA_LIBS} spdlog::spdlog_header_only)
+target_link_libraries(${PROJECT_NAME} GTest::gtest_main ${EXTRA_LIBS} spdlog::spdlog)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize=address)


### PR DESCRIPTION
- No need to look for `fmtlib` as we use the bundled one from `spdlog`
- Use header only `spdlog` in release builds for speed and also to try avoid CRT DLL boundary related issue affecting Windows (Didnt work see #58 )