### PR TITLE
File Watching Fixes to Address Windows Issues

### DIFF
--- a/include/online_sdf_renderer.h
+++ b/include/online_sdf_renderer.h
@@ -47,6 +47,7 @@ class OnlineSDFRenderer : public SDFRenderer {
     void setupRenderContext();
     void createCommandBuffers();
     void createPipeline();
+    void tryRecreatePipeline();
     void calcTimestamps(uint32_t imageIndex);
     void destroyRenderContext();
     void destroyPipeline();

--- a/include/shader_utils.h
+++ b/include/shader_utils.h
@@ -6,9 +6,9 @@
 
 namespace shader_utils {
 // Take a shader file eg. planet.frag
-// and produce planet.spv
-std::filesystem::path compileToPath(const std::string &shaderFilename,
-                              bool useToyTemplate = false);
+// and produce SPIR-V in memory.
+std::vector<uint32_t> compileFileToSpirv(const std::string &shaderFilename,
+                                         bool useToyTemplate = false);
 
 // Compile the embedded fullscreen quad vertex shader directly to SPIR-V.
 std::vector<uint32_t> compileFullscreenQuadVertSpirv();

--- a/src/offline_sdf_renderer.cpp
+++ b/src/offline_sdf_renderer.cpp
@@ -151,10 +151,9 @@ void OfflineSDFRenderer::setupRenderContext() {
 
 void OfflineSDFRenderer::createPipeline() {
     createPipelineLayoutCommon();
-    std::filesystem::path fragSpirvPath =
-        shader_utils::compileToPath(fragShaderPath, useToyTemplate);
-    fragShaderModule =
-        vkutils::createShaderModule(logicalDevice, fragSpirvPath.string());
+    auto fragSpirv =
+        shader_utils::compileFileToSpirv(fragShaderPath, useToyTemplate);
+    fragShaderModule = vkutils::createShaderModule(logicalDevice, fragSpirv);
     pipeline = vkutils::createGraphicsPipeline(
         logicalDevice, renderPass, pipelineLayout, imageSize, vertShaderModule,
         fragShaderModule);

--- a/src/shader_utils.cpp
+++ b/src/shader_utils.cpp
@@ -199,12 +199,11 @@ static std::vector<uint32_t> compileToSpirv(const char *shaderSource,
     return spirv;
 }
 
-std::filesystem::path compileToPath(const std::string &shaderFilename,
-                                    bool useToyTemplate = false) {
-    // Used to compile shaders to a path
-    // With .frag shaders we sometimes use the toy template
-    // which does old school GLSL ShaderToy style format
-    // also eg. with iTime and so on...
+std::vector<uint32_t> compileFileToSpirv(const std::string &shaderFilename,
+                                         bool useToyTemplate) {
+    // Used to compile shaders from a file directly to SPIR-V in memory.
+    // With .frag shaders we sometimes use the toy template which does
+    // old school GLSL ShaderToy style format (eg. iTime and so on).
     spdlog::info("Compiling shader: {}", shaderFilename);
     std::string shaderString;
     std::string shaderExtension =
@@ -217,14 +216,7 @@ std::filesystem::path compileToPath(const std::string &shaderFilename,
         shaderString = readShaderSource(shaderFilename);
     }
 
-    auto spirv = compileToSpirv(shaderString.data(), lang, useToyTemplate);
-
-    // Save to file
-    std::filesystem::path outputPath = shaderFilename;
-    outputPath.replace_extension(".spv");
-    // Convert to string to ensure char* path (Windows uses wchar_t* for paths)
-    glslang::OutputSpvBin(spirv, outputPath.string().c_str());
-    return outputPath;
+    return compileToSpirv(shaderString.data(), lang, useToyTemplate);
 }
 
 std::vector<uint32_t> compileFullscreenQuadVertSpirv() {

--- a/tests/test_shader_comp.cpp
+++ b/tests/test_shader_comp.cpp
@@ -7,21 +7,14 @@
 TEST(ShaderUtilsTest, CompileTest) {
     TempShaderFile tempShader("temp_shader.frag",
                               "#version 450\nvoid main() {}");
-    shader_utils::compileToPath(tempShader.filename());
-
-    std::string expectedSpvFilename = "temp_shader.spv";
-    std::ifstream spvFile(expectedSpvFilename);
-    bool fileExists = spvFile.good();
-    spvFile.close();
-    std::remove(expectedSpvFilename.c_str());
-
-    ASSERT_TRUE(fileExists);
+    auto spirv = shader_utils::compileFileToSpirv(tempShader.filename());
+    ASSERT_FALSE(spirv.empty());
 }
 
 TEST(ShaderUtilsTest, CompileTestBadVersion) {
     TempShaderFile tempShader(
         "temp_shader.frag", "// GLSL Fragment shader example\nvoid main() {}");
-    ASSERT_THROW(shader_utils::compileToPath(tempShader.filename()),
+    ASSERT_THROW(shader_utils::compileFileToSpirv(tempShader.filename()),
                  std::runtime_error);
 }
 
@@ -29,15 +22,8 @@ TEST(ShaderUtilsTest, CompileVertexShader) {
     TempShaderFile tempShader(
         "temp_vertex.vert",
         "#version 450\nvoid main() { gl_Position = vec4(0.0); }");
-    shader_utils::compileToPath(tempShader.filename());
-
-    std::string expectedSpvFilename = "temp_vertex.spv";
-    std::ifstream spvFile(expectedSpvFilename);
-    bool fileExists = spvFile.good();
-    spvFile.close();
-    std::remove(expectedSpvFilename.c_str());
-
-    ASSERT_TRUE(fileExists);
+    auto spirv = shader_utils::compileFileToSpirv(tempShader.filename());
+    ASSERT_FALSE(spirv.empty());
 }
 
 TEST(ShaderUtilsTest, CompileGLSLESTest) {
@@ -52,28 +38,16 @@ TEST(ShaderUtilsTest, CompileGLSLESTest) {
         "    fragColor = vec4(1.0, 0.0, 0.0, 1.0); // Red\n"
         "}");
 
-    shader_utils::compileToPath(tempShader.filename(), true);
-
-    std::string expectedSpvFilename = "temp_glsl_es.spv";
-    std::ifstream spvFile(expectedSpvFilename);
-    bool fileExists = spvFile.good();
-    spvFile.close();
-    std::remove(expectedSpvFilename.c_str());
-
-    ASSERT_TRUE(fileExists);
+    auto spirv =
+        shader_utils::compileFileToSpirv(tempShader.filename(), true);
+    ASSERT_FALSE(spirv.empty());
 }
 
 TEST(ShaderUtilsTest, CompileToyShaderTest) {
     // This shader should compile successfully
-    shader_utils::compileToPath(SHADER_DIR "testtoyshader.frag", true);
-
-    std::string expectedSpvFilename = std::string(SHADER_DIR) + "testtoyshader.spv";
-    std::ifstream spvFile(expectedSpvFilename);
-    bool fileExists = spvFile.good();
-    spvFile.close();
-    std::remove(expectedSpvFilename.c_str());
-
-    ASSERT_TRUE(fileExists);
+    auto spirv = shader_utils::compileFileToSpirv(
+        SHADER_DIR "testtoyshader.frag", true);
+    ASSERT_FALSE(spirv.empty());
 }
 
 TEST(ShaderUtilsTest, CompileToyShaderFailTest) {
@@ -82,18 +56,19 @@ TEST(ShaderUtilsTest, CompileToyShaderFailTest) {
     TempShaderFile tempShader("temp_shader_fail.frag",
                               "void main() {}");
 
-    ASSERT_THROW(shader_utils::compileToPath(tempShader.filename(), true),
+    ASSERT_THROW(
+        shader_utils::compileFileToSpirv(tempShader.filename(), true),
                  std::runtime_error);
 }
 
 TEST(ShaderUtilsTest, FileNotFoundTest) {
-    ASSERT_THROW(shader_utils::compileToPath("non_existent_shader.frag"),
+    ASSERT_THROW(shader_utils::compileFileToSpirv("non_existent_shader.frag"),
                  std::runtime_error);
 }
 
 TEST(ShaderUtilsTest, CompileEmptyFile) {
     TempShaderFile tempShader("empty.frag", "");
-    ASSERT_THROW(shader_utils::compileToPath(tempShader.filename()),
+    ASSERT_THROW(shader_utils::compileFileToSpirv(tempShader.filename()),
                  std::runtime_error);
 }
 
@@ -101,7 +76,7 @@ TEST(ShaderUtilsTest, CompileWithUnknownExtension) {
     TempShaderFile tempShader("shader.txt", "#version 450\nvoid main() {}");
     // glslc typically fails if it can't determine the shader stage from the
     // extension
-    ASSERT_THROW(shader_utils::compileToPath(tempShader.filename()),
+    ASSERT_THROW(shader_utils::compileFileToSpirv(tempShader.filename()),
                  std::runtime_error);
 }
 


### PR DESCRIPTION
- `atomic` `pipelineUpdated` filewatcher `bool` to avoid UB
- avoid intermediate `.spv` files
- fix windows file watcher to be more selective to handle renames

Fixes #59 