### PR TITLE
Resize in CICD + Cleanups

### DIFF
--- a/.github/workflows/linux-smoke-tests.yml
+++ b/.github/workflows/linux-smoke-tests.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Vulkan 100 frame smoke test
         run: |
           xvfb-run -s "-screen 0 1024x768x24" \
-            ./build/vsdf --toy shaders/testtoyshader.frag --frames 100 --headless --log-level info
+            ./build/vsdf --toy shaders/testtoyshader.frag --frames 100 --headless --log-level info --ci-resize-after 50

--- a/include/offline_sdf_renderer.h
+++ b/include/offline_sdf_renderer.h
@@ -17,6 +17,15 @@ inline constexpr uint32_t OFFSCREEN_DEFAULT_WIDTH = 1280;
 inline constexpr uint32_t OFFSCREEN_DEFAULT_HEIGHT = 720;
 inline constexpr uint32_t OFFSCREEN_DEFAULT_RING_SIZE = 2;
 
+struct OfflineRenderOptions {
+    uint32_t maxFrames = 1;
+    std::optional<std::filesystem::path> debugDumpPPMDir = std::nullopt;
+    uint32_t width = OFFSCREEN_DEFAULT_WIDTH;
+    uint32_t height = OFFSCREEN_DEFAULT_HEIGHT;
+    uint32_t ringSize = OFFSCREEN_DEFAULT_RING_SIZE;
+    ffmpeg_utils::EncodeSettings encodeSettings = {};
+};
+
 // Offline SDF Renderer
 // This basis will be used for FFMPEG integration
 class OfflineSDFRenderer : public SDFRenderer {
@@ -84,13 +93,8 @@ class OfflineSDFRenderer : public SDFRenderer {
     OfflineSDFRenderer(const OfflineSDFRenderer &) = delete;
     OfflineSDFRenderer &operator=(const OfflineSDFRenderer &) = delete;
     OfflineSDFRenderer(
-        const std::string &fragShaderPath, uint32_t maxFrames,
-        bool useToyTemplate = false,
-        std::optional<std::filesystem::path> debugDumpPPMDir = std::nullopt,
-        uint32_t width = OFFSCREEN_DEFAULT_WIDTH,
-        uint32_t height = OFFSCREEN_DEFAULT_HEIGHT,
-        uint32_t ringSize = OFFSCREEN_DEFAULT_RING_SIZE,
-        ffmpeg_utils::EncodeSettings encodeSettings = {});
+        const std::string &fragShaderPath, bool useToyTemplate = false,
+        OfflineRenderOptions options = {});
     void setup();
     void renderFrames();
 };

--- a/include/online_sdf_renderer.h
+++ b/include/online_sdf_renderer.h
@@ -13,6 +13,16 @@ struct GLFWApplication {
     bool framebufferResized = false;
 };
 
+struct OnlineRenderOptions {
+    std::optional<uint32_t> maxFrames = std::nullopt;
+    bool headless = false;
+    bool noFocus = false;
+    std::optional<std::filesystem::path> debugDumpPPMDir = std::nullopt;
+    std::optional<uint32_t> ciResizeAfter = std::nullopt;
+    std::optional<uint32_t> ciResizeWidth = std::nullopt;
+    std::optional<uint32_t> ciResizeHeight = std::nullopt;
+};
+
 // Online renderer: Vulkan + swapchain -- meant to be displayed.
 class OnlineSDFRenderer : public SDFRenderer {
   private:
@@ -34,9 +44,8 @@ class OnlineSDFRenderer : public SDFRenderer {
     vkutils::SwapchainImages swapchainImages;
     vkutils::SwapchainImageViews swapchainImageViews;
     vkutils::FrameBuffers frameBuffers;
-    bool headless = false;
-    bool noFocus = false;
-    std::optional<uint32_t> maxFrames;
+    OnlineRenderOptions options{};
+    bool ciResizeTriggered = false;
 
     // Timing
     std::chrono::time_point<std::chrono::high_resolution_clock> cpuStartFrame,
@@ -61,9 +70,7 @@ class OnlineSDFRenderer : public SDFRenderer {
     OnlineSDFRenderer &operator=(const OnlineSDFRenderer &) = delete;
     OnlineSDFRenderer(
         const std::string &fragShaderPath, bool useToyTemplate = false,
-        std::optional<uint32_t> maxFrames = std::nullopt, bool headless = false,
-        std::optional<std::filesystem::path> debugDumpPPMDir = std::nullopt,
-        bool noFocus = false);
+        OnlineRenderOptions options = {});
     void setup();
     void gameLoop();
 };

--- a/include/online_sdf_renderer.h
+++ b/include/online_sdf_renderer.h
@@ -18,6 +18,7 @@ struct OnlineRenderOptions {
     bool headless = false;
     bool noFocus = false;
     std::optional<std::filesystem::path> debugDumpPPMDir = std::nullopt;
+    // For CI to test resize
     std::optional<uint32_t> ciResizeAfter = std::nullopt;
     std::optional<uint32_t> ciResizeWidth = std::nullopt;
     std::optional<uint32_t> ciResizeHeight = std::nullopt;
@@ -45,6 +46,8 @@ class OnlineSDFRenderer : public SDFRenderer {
     vkutils::SwapchainImageViews swapchainImageViews;
     vkutils::FrameBuffers frameBuffers;
     OnlineRenderOptions options{};
+
+    // For CI to test resize
     bool ciResizeTriggered = false;
 
     // Timing
@@ -68,9 +71,9 @@ class OnlineSDFRenderer : public SDFRenderer {
   public:
     OnlineSDFRenderer(const OnlineSDFRenderer &) = delete;
     OnlineSDFRenderer &operator=(const OnlineSDFRenderer &) = delete;
-    OnlineSDFRenderer(
-        const std::string &fragShaderPath, bool useToyTemplate = false,
-        OnlineRenderOptions options = {});
+    OnlineSDFRenderer(const std::string &fragShaderPath,
+                      bool useToyTemplate = false,
+                      OnlineRenderOptions options = {});
     void setup();
     void gameLoop();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -425,15 +425,10 @@ int run(int argc, char **argv) {
         .ciResizeHeight = ciResizeHeight,
     };
 
-    auto runOnline = [&]() {
-        OnlineSDFRenderer renderer{shaderFile.string(), useToyTemplate,
-                                   options};
-        renderer.setup();
-        renderer.gameLoop();
-    };
-
+    bool shouldRunOnline = true;
 #if defined(VSDF_ENABLE_FFMPEG)
     if (useFfmpeg) {
+        shouldRunOnline = false;
         OfflineRenderOptions offlineOptions{
             .maxFrames = *maxFrames,
             .debugDumpPPMDir = debugDumpPPMDir,
@@ -446,12 +441,14 @@ int run(int argc, char **argv) {
                                     std::move(offlineOptions)};
         renderer.setup();
         renderer.renderFrames();
-    } else {
-        runOnline();
     }
-#else
-    runOnline();
 #endif
+    if (shouldRunOnline) {
+        OnlineSDFRenderer renderer{shaderFile.string(), useToyTemplate,
+                                   options};
+        renderer.setup();
+        renderer.gameLoop();
+    }
     return 0;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,6 +327,7 @@ int run(int argc, char **argv) {
         }
 #endif
 
+        // CI-only flags (intentionally undocumented).
         if (arg == "--ci-resize-after") {
             if (i + 1 >= argc) {
                 throw CLIError(
@@ -381,6 +382,7 @@ int run(int argc, char **argv) {
             }
             continue;
         }
+        // END CI-only flags (intentionally undocumented).
 
         if (arg.substr(0, 2) != "--") {
             if (shaderFile.empty()) {
@@ -431,10 +433,15 @@ int run(int argc, char **argv) {
 
 #if defined(VSDF_ENABLE_FFMPEG)
     if (useFfmpeg) {
-        OfflineSDFRenderer renderer{shaderFile.string(), *maxFrames,
-                                    useToyTemplate,      debugDumpPPMDir,
-                                    offlineWidth,        offlineHeight,
-                                    offlineRingSize,     encodeSettings};
+        OfflineRenderOptions offlineOptions{};
+        offlineOptions.maxFrames = *maxFrames;
+        offlineOptions.debugDumpPPMDir = debugDumpPPMDir;
+        offlineOptions.width = offlineWidth;
+        offlineOptions.height = offlineHeight;
+        offlineOptions.ringSize = offlineRingSize;
+        offlineOptions.encodeSettings = encodeSettings;
+        OfflineSDFRenderer renderer{shaderFile.string(), useToyTemplate,
+                                    std::move(offlineOptions)};
         renderer.setup();
         renderer.renderFrames();
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -415,16 +415,6 @@ int run(int argc, char **argv) {
     spdlog::info("Setting things up...");
     spdlog::default_logger()->set_pattern("[%H:%M:%S] [%l] %v");
 
-    OnlineRenderOptions options{
-        .maxFrames = maxFrames,
-        .headless = headless,
-        .noFocus = noFocus,
-        .debugDumpPPMDir = debugDumpPPMDir,
-        .ciResizeAfter = ciResizeAfter,
-        .ciResizeWidth = ciResizeWidth,
-        .ciResizeHeight = ciResizeHeight,
-    };
-
     bool shouldRunOnline = true;
 #if defined(VSDF_ENABLE_FFMPEG)
     if (useFfmpeg) {
@@ -444,6 +434,15 @@ int run(int argc, char **argv) {
     }
 #endif
     if (shouldRunOnline) {
+        OnlineRenderOptions options{
+            .maxFrames = maxFrames,
+            .headless = headless,
+            .noFocus = noFocus,
+            .debugDumpPPMDir = debugDumpPPMDir,
+            .ciResizeAfter = ciResizeAfter,
+            .ciResizeWidth = ciResizeWidth,
+            .ciResizeHeight = ciResizeHeight,
+        };
         OnlineSDFRenderer renderer{shaderFile.string(), useToyTemplate,
                                    options};
         renderer.setup();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -435,7 +435,7 @@ int run(int argc, char **argv) {
     }
 #endif
     if (shouldRunOnline) {
-        OnlineRenderOptions options{
+        OnlineRenderOptions onlineOptions{
             .maxFrames = maxFrames,
             .headless = headless,
             .noFocus = noFocus,
@@ -445,7 +445,7 @@ int run(int argc, char **argv) {
             .ciResizeHeight = ciResizeHeight,
         };
         OnlineSDFRenderer renderer{shaderFile.string(), useToyTemplate,
-                                   options};
+                                   std::move(onlineOptions)};
         renderer.setup();
         renderer.gameLoop();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,48 +215,6 @@ int run(int argc, char **argv) {
             }
             logLevel = parseLogLevel(argv[++i]);
             continue;
-        } else if (arg == "--ci-resize-after") {
-            if (i + 1 >= argc) {
-                throw CLIError("--ci-resize-after requires a positive integer value");
-            }
-            try {
-                ciResizeAfter = static_cast<uint32_t>(std::stoul(argv[++i]));
-            } catch (const std::invalid_argument &) {
-                throw CLIError("--ci-resize-after requires a valid positive integer value");
-            } catch (const std::out_of_range &) {
-                throw CLIError("--ci-resize-after value is out of range for a positive integer");
-            }
-            continue;
-        } else if (arg == "--ci-resize-width") {
-            if (i + 1 >= argc) {
-                throw CLIError("--ci-resize-width requires a positive integer value");
-            }
-            try {
-                ciResizeWidth = static_cast<uint32_t>(std::stoul(argv[++i]));
-            } catch (const std::invalid_argument &) {
-                throw CLIError("--ci-resize-width requires a valid positive integer value");
-            } catch (const std::out_of_range &) {
-                throw CLIError("--ci-resize-width value is out of range for a positive integer");
-            }
-            if (*ciResizeWidth == 0) {
-                throw CLIError("--ci-resize-width requires a positive integer value");
-            }
-            continue;
-        } else if (arg == "--ci-resize-height") {
-            if (i + 1 >= argc) {
-                throw CLIError("--ci-resize-height requires a positive integer value");
-            }
-            try {
-                ciResizeHeight = static_cast<uint32_t>(std::stoul(argv[++i]));
-            } catch (const std::invalid_argument &) {
-                throw CLIError("--ci-resize-height requires a valid positive integer value");
-            } catch (const std::out_of_range &) {
-                throw CLIError("--ci-resize-height value is out of range for a positive integer");
-            }
-            if (*ciResizeHeight == 0) {
-                throw CLIError("--ci-resize-height requires a positive integer value");
-            }
-            continue;
         } else if (arg == "--debug-dump-ppm") {
             if (i + 1 >= argc) {
                 throw CLIError("--debug-dump-ppm requires a directory path");
@@ -368,6 +326,61 @@ int run(int argc, char **argv) {
             continue;
         }
 #endif
+
+        if (arg == "--ci-resize-after") {
+            if (i + 1 >= argc) {
+                throw CLIError(
+                    "--ci-resize-after requires a positive integer value");
+            }
+            try {
+                ciResizeAfter = static_cast<uint32_t>(std::stoul(argv[++i]));
+            } catch (const std::invalid_argument &) {
+                throw CLIError(
+                    "--ci-resize-after requires a valid positive integer value");
+            } catch (const std::out_of_range &) {
+                throw CLIError("--ci-resize-after value is out of range "
+                               "for a positive integer");
+            }
+            continue;
+        } else if (arg == "--ci-resize-width") {
+            if (i + 1 >= argc) {
+                throw CLIError(
+                    "--ci-resize-width requires a positive integer value");
+            }
+            try {
+                ciResizeWidth = static_cast<uint32_t>(std::stoul(argv[++i]));
+            } catch (const std::invalid_argument &) {
+                throw CLIError(
+                    "--ci-resize-width requires a valid positive integer value");
+            } catch (const std::out_of_range &) {
+                throw CLIError("--ci-resize-width value is out of range "
+                               "for a positive integer");
+            }
+            if (*ciResizeWidth == 0) {
+                throw CLIError(
+                    "--ci-resize-width requires a positive integer value");
+            }
+            continue;
+        } else if (arg == "--ci-resize-height") {
+            if (i + 1 >= argc) {
+                throw CLIError(
+                    "--ci-resize-height requires a positive integer value");
+            }
+            try {
+                ciResizeHeight = static_cast<uint32_t>(std::stoul(argv[++i]));
+            } catch (const std::invalid_argument &) {
+                throw CLIError(
+                    "--ci-resize-height requires a valid positive integer value");
+            } catch (const std::out_of_range &) {
+                throw CLIError("--ci-resize-height value is out of range "
+                               "for a positive integer");
+            }
+            if (*ciResizeHeight == 0) {
+                throw CLIError(
+                    "--ci-resize-height requires a positive integer value");
+            }
+            continue;
+        }
 
         if (arg.substr(0, 2) != "--") {
             if (shaderFile.empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,13 +434,14 @@ int run(int argc, char **argv) {
 
 #if defined(VSDF_ENABLE_FFMPEG)
     if (useFfmpeg) {
-        OfflineRenderOptions offlineOptions{};
-        offlineOptions.maxFrames = *maxFrames;
-        offlineOptions.debugDumpPPMDir = debugDumpPPMDir;
-        offlineOptions.width = offlineWidth;
-        offlineOptions.height = offlineHeight;
-        offlineOptions.ringSize = offlineRingSize;
-        offlineOptions.encodeSettings = encodeSettings;
+        OfflineRenderOptions offlineOptions{
+            .maxFrames = *maxFrames,
+            .debugDumpPPMDir = debugDumpPPMDir,
+            .width = offlineWidth,
+            .height = offlineHeight,
+            .ringSize = offlineRingSize,
+            .encodeSettings = encodeSettings,
+        };
         OfflineSDFRenderer renderer{shaderFile.string(), useToyTemplate,
                                     std::move(offlineOptions)};
         renderer.setup();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,7 @@ int run(int argc, char **argv) {
     bool headless = false;
     bool noFocus = false;
     std::optional<std::filesystem::path> debugDumpPPMDir;
+    // For CI to test resize
     std::optional<uint32_t> ciResizeAfter;
     std::optional<uint32_t> ciResizeWidth;
     std::optional<uint32_t> ciResizeHeight;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -415,14 +415,15 @@ int run(int argc, char **argv) {
     spdlog::info("Setting things up...");
     spdlog::default_logger()->set_pattern("[%H:%M:%S] [%l] %v");
 
-    OnlineRenderOptions options{};
-    options.maxFrames = maxFrames;
-    options.headless = headless;
-    options.noFocus = noFocus;
-    options.debugDumpPPMDir = debugDumpPPMDir;
-    options.ciResizeAfter = ciResizeAfter;
-    options.ciResizeWidth = ciResizeWidth;
-    options.ciResizeHeight = ciResizeHeight;
+    OnlineRenderOptions options{
+        .maxFrames = maxFrames,
+        .headless = headless,
+        .noFocus = noFocus,
+        .debugDumpPPMDir = debugDumpPPMDir,
+        .ciResizeAfter = ciResizeAfter,
+        .ciResizeWidth = ciResizeWidth,
+        .ciResizeHeight = ciResizeHeight,
+    };
 
     auto runOnline = [&]() {
         OnlineSDFRenderer renderer{shaderFile.string(), useToyTemplate,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,8 +336,8 @@ int run(int argc, char **argv) {
             try {
                 ciResizeAfter = static_cast<uint32_t>(std::stoul(argv[++i]));
             } catch (const std::invalid_argument &) {
-                throw CLIError(
-                    "--ci-resize-after requires a valid positive integer value");
+                throw CLIError("--ci-resize-after requires a valid positive "
+                               "integer value");
             } catch (const std::out_of_range &) {
                 throw CLIError("--ci-resize-after value is out of range "
                                "for a positive integer");
@@ -351,8 +351,8 @@ int run(int argc, char **argv) {
             try {
                 ciResizeWidth = static_cast<uint32_t>(std::stoul(argv[++i]));
             } catch (const std::invalid_argument &) {
-                throw CLIError(
-                    "--ci-resize-width requires a valid positive integer value");
+                throw CLIError("--ci-resize-width requires a valid positive "
+                               "integer value");
             } catch (const std::out_of_range &) {
                 throw CLIError("--ci-resize-width value is out of range "
                                "for a positive integer");
@@ -370,8 +370,8 @@ int run(int argc, char **argv) {
             try {
                 ciResizeHeight = static_cast<uint32_t>(std::stoul(argv[++i]));
             } catch (const std::invalid_argument &) {
-                throw CLIError(
-                    "--ci-resize-height requires a valid positive integer value");
+                throw CLIError("--ci-resize-height requires a valid positive "
+                               "integer value");
             } catch (const std::out_of_range &) {
                 throw CLIError("--ci-resize-height value is out of range "
                                "for a positive integer");

--- a/src/offline_sdf_renderer.cpp
+++ b/src/offline_sdf_renderer.cpp
@@ -8,13 +8,13 @@
 #include <stdexcept>
 
 OfflineSDFRenderer::OfflineSDFRenderer(
-    const std::string &fragShaderPath, uint32_t maxFrames, bool useToyTemplate,
-    std::optional<std::filesystem::path> debugDumpPPMDir, uint32_t width,
-    uint32_t height, uint32_t ringSize,
-    ffmpeg_utils::EncodeSettings encodeSettings)
-    : SDFRenderer(fragShaderPath, useToyTemplate, debugDumpPPMDir),
-      imageSize({width, height}), ringSize(validateRingSize(ringSize)),
-      maxFrames(maxFrames), encodeSettings(std::move(encodeSettings)) {}
+    const std::string &fragShaderPath, bool useToyTemplate,
+    OfflineRenderOptions options)
+    : SDFRenderer(fragShaderPath, useToyTemplate, options.debugDumpPPMDir),
+      imageSize({options.width, options.height}),
+      ringSize(validateRingSize(options.ringSize)),
+      maxFrames(options.maxFrames),
+      encodeSettings(std::move(options.encodeSettings)) {}
 
 uint32_t OfflineSDFRenderer::validateRingSize(uint32_t value) {
     if (value == 0 || value > MAX_FRAME_SLOTS) {


### PR DESCRIPTION
- `ci-` flags eg. `--ci-trigger-resize-after` `x frames` ~~to try and catch ASAN leaks on resize eg. #69~~ to test resize during CI (wont catch all issues)
- Use options `struct` for the online/offline renderer
- Other minor fixes and cleanups